### PR TITLE
calloc: Don't zero-out memory allocated with mmap

### DIFF
--- a/malloc.c
+++ b/malloc.c
@@ -588,7 +588,7 @@ void *calloc(size_t m, size_t n)
 	n *= m;
 	void *p = malloc(n);
 	if (!p) return p;
-	return memset(p, 0, n);
+	return n >= MMAP_THRESHOLD ? p : memset(p, 0, n);
 }
 
 size_t malloc_usable_size(void *p)


### PR DESCRIPTION
mmap() already provides zeroed-out memory, so avoid zeroing it out in calloc().